### PR TITLE
Update Unifi from 6.2.26 to 6.4.54

### DIFF
--- a/unifi/Dockerfile
+++ b/unifi/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         openjdk-8-jdk-headless=8u292-b10-0ubuntu1~18.04 \
     \
     && curl -J -L -o /tmp/unifi.deb \
-        "https://dl.ui.com/unifi/6.2.26/unifi_sysvinit_all.deb" \
+        "https://dl.ui.com/unifi/6.4.54/unifi_sysvinit_all.deb" \
     \
     && dpkg --install /tmp/unifi.deb \
     \


### PR DESCRIPTION
Current Unifi is severely outdated. Needs to patch with new version.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
